### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/simple-reflect.cabal
+++ b/simple-reflect.cabal
@@ -7,7 +7,7 @@ author:              Twan van Laarhoven
 maintainer:          twanvl@gmail.com
 bug-reports:         https://github.com/twanvl/simple-reflect/issues
 category:            Debug
-cabal-version:       >= 1.6
+cabal-version:       >= 1.8
 build-type:          Simple
 synopsis:            Simple reflection of expressions containing variables
 description:


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: simple-reflect.cabal:25:38: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```